### PR TITLE
Support .ecspresso-version

### DIFF
--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo ".ecspresso-version"


### PR DESCRIPTION
- https://github.com/kayac/ecspresso/pull/490 makes `.ecspresso-version` available.
- It would be convenient if asdf can see this file and determine the version.