### PR TITLE
rename koluku to kayac

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 koluku
+Copyright (c) 2022 KAYAC Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# asdf-ecspresso [![Build](https://github.com/koluku/asdf-ecspresso/actions/workflows/build.yml/badge.svg)](https://github.com/koluku/asdf-ecspresso/actions/workflows/build.yml) [![Lint](https://github.com/koluku/asdf-ecspresso/actions/workflows/lint.yml/badge.svg)](https://github.com/koluku/asdf-ecspresso/actions/workflows/lint.yml)
+# asdf-ecspresso [![Build](https://github.com/kayac/asdf-ecspresso/actions/workflows/build.yml/badge.svg)](https://github.com/kayac/asdf-ecspresso/actions/workflows/build.yml) [![Lint](https://github.com/kayac/asdf-ecspresso/actions/workflows/lint.yml/badge.svg)](https://github.com/kayac/asdf-ecspresso/actions/workflows/lint.yml)
 
 
 [ecspresso](https://github.com/kayac/ecspresso) plugin for the [asdf version manager](https://asdf-vm.com).
@@ -28,7 +28,7 @@ Plugin:
 ```shell
 asdf plugin add ecspresso
 # or
-asdf plugin add ecspresso https://github.com/koluku/asdf-ecspresso.git
+asdf plugin add ecspresso https://github.com/kayac/asdf-ecspresso.git
 ```
 
 ecspresso:
@@ -54,8 +54,8 @@ install & manage versions.
 
 Contributions of any kind welcome! See the [contributing guide](contributing.md).
 
-[Thanks goes to these contributors](https://github.com/koluku/asdf-ecspresso/graphs/contributors)!
+[Thanks goes to these contributors](https://github.com/kayac/asdf-ecspresso/graphs/contributors)!
 
 # License
 
-See [LICENSE](LICENSE) © [koluku](https://github.com/koluku/)
+See [LICENSE](LICENSE) © [KAYAC Inc.](https://github.com/kayac/)

--- a/contributing.md
+++ b/contributing.md
@@ -6,7 +6,7 @@ Testing Locally:
 asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
 
 #
-asdf plugin test ecspresso https://github.com/koluku/asdf-ecspresso.git "ecspresso version"
+asdf plugin test ecspresso https://github.com/kayac/asdf-ecspresso.git "ecspresso version"
 ```
 
 Tests are automatically run in GitHub Actions on push and PR.


### PR DESCRIPTION
This repository is transferred from koluku/asdf-ecspresso.
It must be renamed as kayac owner.