### PR TITLE
support aarch64

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -23,6 +23,9 @@ get_arch() {
   local arch
   arch=$(uname -m | tr '[:upper:]' '[:lower:]')
   case ${arch} in
+  aarch64)
+    arch='arm64'
+    ;;
   x86_64)
     arch='amd64'
     ;;


### PR DESCRIPTION
Supports os which `uname -m` returns `aarch` like debian.

```console
$ uname -m
aarch64

$ asdf install ecspresso latest
* Downloading ecspresso release 2.2.3...
curl: (22) The requested URL returned error: 404 
asdf-ecspresso: Could not download https://github.com/kayac/ecspresso/releases/download/v2.2.3/ecspresso_2.2.3_linux_aarch64.tar.gz

$ asdf plugin test ecspresso https://github.com/handlename/asdf-ecspresso.git --asdf-plugin-gitref fix/support-aarch64 ecspresso version
Updating ecspresso to fix/support-aarch64
From https://github.com/handlename/asdf-ecspresso
 * [new branch]      fix/support-aarch64 -> fix/support-aarch64
Switched to branch 'fix/support-aarch64'
* Downloading ecspresso release 2.2.3...
ecspresso 2.2.3 installation was successful!
ecspresso v2.2.3
```
